### PR TITLE
#42 Package Management Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+#EightShapes Design System
+
+## Repository Structure
+The EightShapes Design system is a monorepo containing design system components, tokens, icons and visual assets. Each of these assets is published as an independently versioned node package. 
+
+The dependencies between these assets are managed using [lerna](https://lerna.js.org). 
+
+### Dependency Tree
+To view a dependency tree of the repository, in the _root_ of the repo run:
+
+```
+npm run dependency-tree
+```


### PR DESCRIPTION
Addresses: https://github.com/EightShapes/esds-project/issues/42

I'm not sure what else to doc for "package management." @nathanacurtis is there something I'm missing?

I assume this is only the start of a fully fleshed out readme for the repo that will cover other "system wide" topics, separate from package-specific readme files.